### PR TITLE
docs: Add link to EmailTemplate module documentation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -66,6 +66,7 @@ nav:
         - Modules:
              - ContentFields: reference/modules/ContentFields.md
              - DisplayHelpers: reference/modules/DisplayHelpers.md
+             - EmailTemplates: reference/modules/EmailTemplates.md
              - GCCollab: reference/modules/GCCollab.md
              - GitHub: reference/modules/GitHub.md
              - LocalizedText: reference/modules/LocalizedText.md


### PR DESCRIPTION
* EmailTemplate module documentation was not accessible through the table of contents
* Adds a link to the EmailTemplate module page