### PR TITLE
fix: asset pipeline ignoring Apps

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -157,7 +157,7 @@ function getAllAssetGroups() {
 
 function getAssetsJsonPaths() {
   return glob.sync(
-    "./src/{Modules,Themes, Apps}/*/Assets.json",
+    "./src/{Modules,Themes,Apps}/*/Assets.json",
     {}
   );
 }


### PR DESCRIPTION
The whitespace is causing the pipeline to ignore /Apps.